### PR TITLE
Implement dynamic loading prototype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,10 @@
   </modules>
 
   <properties>
-    <java.compiler.source>8</java.compiler.source>
-    <java.compiler.target>8</java.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.compiler.source>11</java.compiler.source>
+    <java.compiler.target>11</java.compiler.target>
   </properties>
 
   <build>

--- a/service-address/pom.xml
+++ b/service-address/pom.xml
@@ -13,7 +13,6 @@
 
   <properties>
     <pf4j.version>2.6.0</pf4j.version>
-    <java.version>1.8</java.version>
 
     <!-- Override below properties in each plugin's pom.xml -->
     <plugin.id>address-service</plugin.id>
@@ -45,11 +44,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
       </plugin>
 
       <plugin>

--- a/service-address/pom.xml
+++ b/service-address/pom.xml
@@ -10,14 +10,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>service-address</artifactId>
+  <version>0.1.0</version>
 
   <properties>
     <pf4j.version>2.6.0</pf4j.version>
-
-    <!-- Override below properties in each plugin's pom.xml -->
     <plugin.id>address-service</plugin.id>
     <plugin.class>com.exonum.osgi.prototype.addressService.AddressServicePlugin</plugin.class>
-    <plugin.version>0.0.1</plugin.version>
+    <plugin.version>${project.version}</plugin.version>
     <plugin.provider>Exonum</plugin.provider>
     <plugin.dependencies></plugin.dependencies>
   </properties>

--- a/service-address/pom.xml
+++ b/service-address/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>service-address</artifactId>
 
   <properties>
-    <pf4j.version>2.4.0</pf4j.version>
+    <pf4j.version>2.6.0</pf4j.version>
     <java.version>1.8</java.version>
 
     <!-- Override below properties in each plugin's pom.xml -->

--- a/service-address/src/main/java/com/exonum/osgi/prototype/addressService/AddressServicePlugin.java
+++ b/service-address/src/main/java/com/exonum/osgi/prototype/addressService/AddressServicePlugin.java
@@ -16,7 +16,7 @@ public class AddressServicePlugin extends Plugin {
 
   @Override
   public void start() throws PluginException {
-    System.out.println("AddressService plugin stared");
+    System.out.println("AddressService plugin started");
     super.start();
   }
 

--- a/service-runtime/pom.xml
+++ b/service-runtime/pom.xml
@@ -13,7 +13,7 @@
   <artifactId>service-runtime</artifactId>
 
   <properties>
-    <pf4j.version>2.4.0</pf4j.version>
+    <pf4j.version>2.6.0</pf4j.version>
     <java.version>1.8</java.version>
     <slf4j.version>1.7.5</slf4j.version>
   </properties>

--- a/service-runtime/pom.xml
+++ b/service-runtime/pom.xml
@@ -14,7 +14,6 @@
 
   <properties>
     <pf4j.version>2.6.0</pf4j.version>
-    <java.version>1.8</java.version>
     <slf4j.version>1.7.5</slf4j.version>
   </properties>
 
@@ -56,11 +55,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/service-runtime/src/main/java/com/exonum/osgi/prototype/DynamicModulesMain.java
+++ b/service-runtime/src/main/java/com/exonum/osgi/prototype/DynamicModulesMain.java
@@ -1,50 +1,77 @@
 package com.exonum.osgi.prototype;
 
-import com.exonum.osgi.prototype.service.UserService;
-import java.io.Console;
+import static java.util.stream.Collectors.toList;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.pf4j.DefaultPluginManager;
+import org.pf4j.PluginManager;
 
 public class DynamicModulesMain {
 
+  // /home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-1.0-SNAPSHOT-plugin.jar /home/dmitry/Documents/dynamic-services-makarov-proto/service-user/target/service-user-1.0-SNAPSHOT-plugin.jar
   public static void main(String[] args) {
-    String basePath;
-    if (args.length != 1) {
-      basePath = "";
-    } else {
-      basePath = args[0];
-    }
+    List<Path> pluginPaths = Arrays.stream(args)
+        .map(path -> Path.of(path))
+        .collect(toList());
 
-    UserService userService = null;
+    PluginManager pluginManager = new DefaultPluginManager();
 
-    boolean active = true;
-    while (active) {
-      Console console = System.console();
-      String command = console.readLine("command: ");
+    List<String> loadedPlugins = loadPlugins(pluginManager, pluginPaths);
 
-      String moduleName;
-      switch (command) {
-        case "load":
-          moduleName = console.readLine("module name: ");
-          System.out.println("Loading module: " + moduleName);
-          //loader.loadModule(moduleName, null);
-          continue;
-        case "unload":
-          moduleName = console.readLine("module name: ");
-          System.out.println("UnLoading module: " + moduleName);
-          continue;
-        case "exec":
-          String userName = console.readLine("user name: ");
-          System.out.println("Executing logic.");
-          userService.getUserDetails(userName);
-          continue;
-        case "exit":
-          System.out.println("Exiting application");
-          active = false;
-          continue;
-        default:
-          System.out.println("Unknown command. Use load, unload, exit commands");
+    startPlugins(pluginManager, loadedPlugins);
+
+    stopPlugins(pluginManager, loadedPlugins);
+
+    unloadPlugins(pluginManager, loadedPlugins);
+  }
+
+  /**
+   * Loads the plugins by paths to their JAR-files.
+   * @param pluginJars a list of plugins to load
+   * @return a list of pluginIds of loaded plugins
+   * @throws IllegalArgumentException if some plugins could not be loaded
+   */
+  private static List<String> loadPlugins(PluginManager pluginManager, List<Path> pluginJars) {
+    List<String> loadedPlugins = new ArrayList<>(pluginJars.size());
+    for (Path pluginJar : pluginJars) {
+      System.out.println("\uD83D\uDE80 Loading " + pluginJar);
+
+      String pluginId = pluginManager.loadPlugin(pluginJar);
+      if (pluginId == null) {
+        // Why don't PluginManager#loadPlugin throw itself? How could clients possibly know
+        // why it failed to load a plugin?
+        throw new IllegalArgumentException("Could not load plugin " + pluginJar);
       }
-    }
 
+      System.out.println("\uD83D\uDE80 Loaded " + pluginId + " (" + pluginJar + ")");
+      loadedPlugins.add(pluginId);
+    }
+    return loadedPlugins;
+  }
+
+  private static void startPlugins(PluginManager pluginManager, List<String> plugins) {
+    System.out.println("Starting plugins: " + plugins);
+
+    plugins.forEach(pluginManager::startPlugin);
+
+    System.out.println("Started plugins: " + pluginManager.getStartedPlugins());
+  }
+
+  private static void stopPlugins(PluginManager pluginManager, List<String> plugins) {
+    System.out.println("Stopping plugins " + plugins);
+
+    plugins.stream()
+        .peek(pluginId -> System.out.println("Stopping " + pluginId))
+        .forEach(pluginManager::stopPlugin);
+  }
+
+  private static void unloadPlugins(PluginManager pluginManager, List<String> loadedPlugins) {
+    System.out.println("Unloading plugins " + loadedPlugins);
+
+    loadedPlugins.forEach(pluginManager::unloadPlugin);
   }
 
 }

--- a/service-user/pom.xml
+++ b/service-user/pom.xml
@@ -13,7 +13,6 @@
 
   <properties>
     <pf4j.version>2.6.0</pf4j.version>
-    <java.version>1.8</java.version>
 
     <!-- Override below properties in each plugin's pom.xml -->
     <plugin.id>user-service</plugin.id>
@@ -45,11 +44,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
       </plugin>
 
       <plugin>

--- a/service-user/pom.xml
+++ b/service-user/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>service-user</artifactId>
 
   <properties>
-    <pf4j.version>2.4.0</pf4j.version>
+    <pf4j.version>2.6.0</pf4j.version>
     <java.version>1.8</java.version>
 
     <!-- Override below properties in each plugin's pom.xml -->

--- a/service-user/src/main/java/com/exonum/osgi/prototype/userService/UserServicePlugin.java
+++ b/service-user/src/main/java/com/exonum/osgi/prototype/userService/UserServicePlugin.java
@@ -1,6 +1,5 @@
 package com.exonum.osgi.prototype.userService;
 
-import com.exonum.osgi.prototype.model.Address;
 import com.exonum.osgi.prototype.model.User;
 import com.exonum.osgi.prototype.service.AddressService;
 import com.exonum.osgi.prototype.service.UserService;
@@ -19,7 +18,7 @@ public class UserServicePlugin extends Plugin {
 
   @Override
   public void start() throws PluginException {
-    System.out.println("UserService plugin stared");
+    System.out.println("UserService plugin started");
     super.start();
   }
 

--- a/services-common/pom.xml
+++ b/services-common/pom.xml
@@ -13,7 +13,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <pf4j.version>2.4.0</pf4j.version>
+    <pf4j.version>2.6.0</pf4j.version>
   </properties>
 
   <dependencies>

--- a/services-common/src/main/java/com/exonum/osgi/prototype/service/AddressService.java
+++ b/services-common/src/main/java/com/exonum/osgi/prototype/service/AddressService.java
@@ -1,7 +1,6 @@
 package com.exonum.osgi.prototype.service;
 
 import com.exonum.osgi.prototype.model.Address;
-import com.exonum.osgi.prototype.model.User;
 import org.pf4j.ExtensionPoint;
 
 public interface AddressService extends ExtensionPoint {


### PR DESCRIPTION
Implement dynamic loading of plugins by their paths to be able to confirm that it works properly and verify a hypothesis that the most recent version of PF4J does *not* support loading of several versions of the same plugin.

<details>

 <summary>Log of a silently failing attempt to load address-service v0.1 & v0.2 simultaneously</summary>
<p>

```
2019-02-11 16:59:59,734 INFO org.pf4j.DefaultPluginStatusProvider - Enabled plugins: []
2019-02-11 16:59:59,734 INFO org.pf4j.DefaultPluginStatusProvider - Disabled plugins: []
2019-02-11 16:59:59,738 INFO org.pf4j.DefaultPluginManager - PF4J version 2.6.0 in 'deployment' mode
🚀 Loading /home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.1.0-plugin.jar
2019-02-11 16:59:59,746 DEBUG org.pf4j.AbstractPluginManager - Loading plugin from '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.1.0-plugin.jar'
2019-02-11 16:59:59,746 DEBUG org.pf4j.AbstractPluginManager - Use 'org.pf4j.CompoundPluginDescriptorFinder@376b4233' to find plugins descriptors
2019-02-11 16:59:59,746 DEBUG org.pf4j.AbstractPluginManager - Finding plugin descriptor for plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.1.0-plugin.jar'
2019-02-11 16:59:59,746 DEBUG org.pf4j.CompoundPluginDescriptorFinder - 'org.pf4j.PropertiesPluginDescriptorFinder@2fd66ad3' is applicable for plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.1.0-plugin.jar'
2019-02-11 16:59:59,777 DEBUG org.pf4j.PropertiesPluginDescriptorFinder - Lookup plugin descriptor in 'plugin.properties'
2019-02-11 16:59:59,784 DEBUG org.pf4j.CompoundPluginDescriptorFinder - Cannot find 'plugin.properties' path
2019-02-11 16:59:59,784 DEBUG org.pf4j.CompoundPluginDescriptorFinder - Try to continue with the next finder
2019-02-11 16:59:59,784 DEBUG org.pf4j.CompoundPluginDescriptorFinder - 'org.pf4j.ManifestPluginDescriptorFinder@679b62af' is applicable for plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.1.0-plugin.jar'
2019-02-11 16:59:59,787 DEBUG org.pf4j.AbstractPluginManager - Found descriptor PluginDescriptor [pluginId=address-service, pluginClass=com.exonum.osgi.prototype.addressService.AddressServicePlugin, version=0.1.0, provider=Exonum, dependencies=[], description=, requires=*, license=null]
2019-02-11 16:59:59,787 DEBUG org.pf4j.AbstractPluginManager - Class 'com.exonum.osgi.prototype.addressService.AddressServicePlugin' for plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.1.0-plugin.jar'
2019-02-11 16:59:59,787 DEBUG org.pf4j.AbstractPluginManager - Loading plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.1.0-plugin.jar'
2019-02-11 16:59:59,787 DEBUG org.pf4j.CompoundPluginLoader - 'org.pf4j.DefaultPluginLoader@2bbaf4f0' is not applicable for plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.1.0-plugin.jar'
2019-02-11 16:59:59,787 DEBUG org.pf4j.CompoundPluginLoader - 'org.pf4j.JarPluginLoader@11c20519' is applicable for plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.1.0-plugin.jar'
2019-02-11 16:59:59,788 DEBUG org.pf4j.PluginClassLoader - Add 'file:/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.1.0-plugin.jar'
2019-02-11 16:59:59,788 DEBUG org.pf4j.AbstractPluginManager - Loaded plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.1.0-plugin.jar' with class loader 'org.pf4j.PluginClassLoader@365c30cc'
2019-02-11 16:59:59,789 DEBUG org.pf4j.AbstractPluginManager - Creating wrapper for plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.1.0-plugin.jar'
2019-02-11 16:59:59,790 DEBUG org.pf4j.AbstractPluginManager - Created wrapper 'PluginWrapper [descriptor=PluginDescriptor [pluginId=address-service, pluginClass=com.exonum.osgi.prototype.addressService.AddressServicePlugin, version=0.1.0, provider=Exonum, dependencies=[], description=, requires=*, license=null], pluginPath=/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.1.0-plugin.jar]' for plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.1.0-plugin.jar'
2019-02-11 16:59:59,791 DEBUG org.pf4j.DependencyResolver - Graph: 
   address-service -> []
2019-02-11 16:59:59,791 DEBUG org.pf4j.DependencyResolver - Plugins order: [address-service]
2019-02-11 16:59:59,792 INFO org.pf4j.AbstractPluginManager - Plugin 'address-service@0.1.0' resolved
🚀 Loaded address-service (/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.1.0-plugin.jar)
🚀 Loading /home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.2.2-plugin.jar
2019-02-11 16:59:59,812 DEBUG org.pf4j.AbstractPluginManager - Loading plugin from '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.2.2-plugin.jar'
2019-02-11 16:59:59,813 DEBUG org.pf4j.AbstractPluginManager - Use 'org.pf4j.CompoundPluginDescriptorFinder@376b4233' to find plugins descriptors
2019-02-11 16:59:59,813 DEBUG org.pf4j.AbstractPluginManager - Finding plugin descriptor for plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.2.2-plugin.jar'
2019-02-11 16:59:59,813 DEBUG org.pf4j.CompoundPluginDescriptorFinder - 'org.pf4j.PropertiesPluginDescriptorFinder@2fd66ad3' is applicable for plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.2.2-plugin.jar'
2019-02-11 16:59:59,815 DEBUG org.pf4j.PropertiesPluginDescriptorFinder - Lookup plugin descriptor in 'plugin.properties'
2019-02-11 16:59:59,815 DEBUG org.pf4j.CompoundPluginDescriptorFinder - Cannot find 'plugin.properties' path
2019-02-11 16:59:59,815 DEBUG org.pf4j.CompoundPluginDescriptorFinder - Try to continue with the next finder
2019-02-11 16:59:59,816 DEBUG org.pf4j.CompoundPluginDescriptorFinder - 'org.pf4j.ManifestPluginDescriptorFinder@679b62af' is applicable for plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.2.2-plugin.jar'
2019-02-11 16:59:59,816 DEBUG org.pf4j.AbstractPluginManager - Found descriptor PluginDescriptor [pluginId=address-service, pluginClass=com.exonum.osgi.prototype.addressService.AddressServicePlugin, version=0.2.2, provider=Exonum, dependencies=[], description=, requires=*, license=null]
2019-02-11 16:59:59,816 DEBUG org.pf4j.AbstractPluginManager - Class 'com.exonum.osgi.prototype.addressService.AddressServicePlugin' for plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.2.2-plugin.jar'
2019-02-11 16:59:59,817 DEBUG org.pf4j.AbstractPluginManager - Loading plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.2.2-plugin.jar'
2019-02-11 16:59:59,817 DEBUG org.pf4j.CompoundPluginLoader - 'org.pf4j.DefaultPluginLoader@2bbaf4f0' is not applicable for plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.2.2-plugin.jar'
2019-02-11 16:59:59,817 DEBUG org.pf4j.CompoundPluginLoader - 'org.pf4j.JarPluginLoader@11c20519' is applicable for plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.2.2-plugin.jar'
2019-02-11 16:59:59,817 DEBUG org.pf4j.PluginClassLoader - Add 'file:/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.2.2-plugin.jar'
2019-02-11 16:59:59,817 DEBUG org.pf4j.AbstractPluginManager - Loaded plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.2.2-plugin.jar' with class loader 'org.pf4j.PluginClassLoader@27c6e487'
2019-02-11 16:59:59,817 DEBUG org.pf4j.AbstractPluginManager - Creating wrapper for plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.2.2-plugin.jar'
2019-02-11 16:59:59,817 DEBUG org.pf4j.AbstractPluginManager - Created wrapper 'PluginWrapper [descriptor=PluginDescriptor [pluginId=address-service, pluginClass=com.exonum.osgi.prototype.addressService.AddressServicePlugin, version=0.2.2, provider=Exonum, dependencies=[], description=, requires=*, license=null], pluginPath=/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.2.2-plugin.jar]' for plugin '/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.2.2-plugin.jar'
2019-02-11 16:59:59,818 DEBUG org.pf4j.DependencyResolver - Graph: 
   address-service -> []
2019-02-11 16:59:59,818 DEBUG org.pf4j.DependencyResolver - Plugins order: [address-service]
2019-02-11 16:59:59,818 INFO org.pf4j.AbstractPluginManager - Plugin 'address-service@0.2.2' resolved
🚀 Loaded address-service (/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.2.2-plugin.jar)
Starting plugins: [address-service, address-service]
2019-02-11 16:59:59,820 INFO org.pf4j.AbstractPluginManager - Start plugin 'address-service@0.2.2'
2019-02-11 16:59:59,820 DEBUG org.pf4j.DefaultPluginFactory - Create instance for plugin 'com.exonum.osgi.prototype.addressService.AddressServicePlugin'
AddressService plugin stared
2019-02-11 16:59:59,822 DEBUG org.pf4j.AbstractPluginManager - Already started plugin 'address-service@0.2.2'
Started plugins: [PluginWrapper [descriptor=PluginDescriptor [pluginId=address-service, pluginClass=com.exonum.osgi.prototype.addressService.AddressServicePlugin, version=0.2.2, provider=Exonum, dependencies=[], description=, requires=*, license=null], pluginPath=/home/dmitry/Documents/dynamic-services-makarov-proto/service-address/target/service-address-0.2.2-plugin.jar]]
Stopping plugins [address-service, address-service]
Stopping address-service
2019-02-11 16:59:59,825 INFO org.pf4j.AbstractPluginManager - Stop plugin 'address-service@0.2.2'
AddressService plugin stopped
Stopping address-service
2019-02-11 16:59:59,826 DEBUG org.pf4j.AbstractPluginManager - Already stopped plugin 'address-service@0.2.2'
Unloading plugins [address-service, address-service]
2019-02-11 16:59:59,827 DEBUG org.pf4j.AbstractPluginManager - Already stopped plugin 'address-service@0.2.2'
2019-02-11 16:59:59,827 INFO org.pf4j.AbstractPluginManager - Unload plugin 'address-service@0.2.2'
Remaining plugins: []
```

</p>
</details>